### PR TITLE
Completely clear default profile in set-profile

### DIFF
--- a/bin/set-profile.js
+++ b/bin/set-profile.js
@@ -21,7 +21,7 @@ function setProfile (p) {
         throw new Error(`profile '${p}' could not be found`)
       }
 
-      profiles.default = Object.assign(profiles.default || {}, profiles[p])
+      profiles.default = Object.assign({}, profiles[p])
 
       return writeFilePromise(credsFile, ini.encode(profiles))
     })


### PR DESCRIPTION
If the default credentials is a superset of the incoming profile credentials, the non-overlapping values will not be overwritten.

i.e.
```
[default]
key_1=val_1
key_2=val_2

[foo]
key_1=val_3
```

The current result of `set-profile foo` will be

```
[default]
key_1=val_3
key_2=val_2

[foo]
key_1=val_3
```
